### PR TITLE
Updated numerous classes to contain a prefix swp_

### DIFF
--- a/functions/header-meta-tags.php
+++ b/functions/header-meta-tags.php
@@ -249,35 +249,63 @@ function swp_open_graph_html($info) {
 	// Check to ensure that we don't need to defer to Yoast
 	if(false === $info['yoast_og_setting']):
 
-		$info['html_output'] .= PHP_EOL . '<meta property="og:type" content="'. trim( $info['meta_tag_values']['og_type'] ).'" />';
-		$info['html_output'] .= PHP_EOL . '<meta property="og:title" content="'. trim( $info['meta_tag_values']['og_title'] ).'" />';
-		$info['html_output'] .= PHP_EOL . '<meta property="og:description" content="'. trim( $info['meta_tag_values']['og_description'] ).'" />';
+		if( isset( $info['meta_tag_values']['og_type'] ) && !empty( $info['meta_tag_values']['og_type'] ) ) :
+			$info['html_output'] .= PHP_EOL . '<meta property="og:type" content="'. trim( $info['meta_tag_values']['og_type'] ).'" />';
+		endif;
+
+		if( isset( $info['meta_tag_values']['og_title'] ) && !empty( $info['meta_tag_values']['og_title'] ) ) :
+			$info['html_output'] .= PHP_EOL . '<meta property="og:title" content="'. trim( $info['meta_tag_values']['og_title'] ).'" />';
+		endif;
+
+		if( isset( $info['meta_tag_values']['og_description'] ) && !empty( $info['meta_tag_values']['og_description'] ) ) :
+			$info['html_output'] .= PHP_EOL . '<meta property="og:description" content="'. trim( $info['meta_tag_values']['og_description'] ).'" />';
+		endif;
 
 		if( isset( $info[ 'meta_tag_values'][ 'og_image' ] )         && !empty( $info['meta_tag_values']['og_image'] ) ) :
 		    $info['html_output'] .= PHP_EOL . '<meta property="og:image" content="'. trim( $info['meta_tag_values']['og_image'] ).'" />';
 		endif;
-	        if( isset( $info[ 'meta_tag_values'][ 'og_image_width' ] )  && !empty( $info['meta_tag_values']['og_image_width'] ) ):
-	            $info['html_output'] .= PHP_EOL . '<meta property="og:image:width" content="'. trim( $info['meta_tag_values']['og_image_width'] ).'" />';
-		endif;
-	        if( isset( $info[ 'meta_tag_values'][ 'og_image_height' ] ) && !empty( $info['meta_tag_values']['og_image_height'] ) ):	    
-	            $info['html_output'] .= PHP_EOL . '<meta property="og:image:height" content="'. trim( $info['meta_tag_values']['og_image_height'] ).'" />';
+
+	    if( isset( $info[ 'meta_tag_values'][ 'og_image_width' ] )  && !empty( $info['meta_tag_values']['og_image_width'] ) ):
+	        $info['html_output'] .= PHP_EOL . '<meta property="og:image:width" content="'. trim( $info['meta_tag_values']['og_image_width'] ).'" />';
 		endif;
 
-		$info['html_output'] .= PHP_EOL . '<meta property="og:url" content="'. trim( $info['meta_tag_values']['og_url'] ).'" />';
-		$info['html_output'] .= PHP_EOL . '<meta property="og:site_name" content="'. trim( $info['meta_tag_values']['og_site_name'] ).'" />';
+	    if( isset( $info[ 'meta_tag_values'][ 'og_image_height' ] ) && !empty( $info['meta_tag_values']['og_image_height'] ) ):
+	        $info['html_output'] .= PHP_EOL . '<meta property="og:image:height" content="'. trim( $info['meta_tag_values']['og_image_height'] ).'" />';
+		endif;
 
-		if( !empty( $info['meta_tag_values']['article_author'] ) ):
+
+		if( isset( $info['meta_tag_values']['og_url'] ) && !empty( $info['meta_tag_values']['og_url'] ) ) :
+			$info['html_output'] .= PHP_EOL . '<meta property="og:url" content="'. trim( $info['meta_tag_values']['og_url'] ).'" />';
+		endif;
+
+		if( isset( $info['meta_tag_values']['og_site_name'] ) && !empty( $info['meta_tag_values']['og_site_name'] ) ) :
+			$info['html_output'] .= PHP_EOL . '<meta property="og:site_name" content="'. trim( $info['meta_tag_values']['og_site_name'] ).'" />';
+		endif;
+
+		if( isset( $info['meta_tag_values']['article_author'] ) && !empty( $info['meta_tag_values']['article_author'] ) ):
 			$info['html_output'] .= PHP_EOL . '<meta property="article:author" content="'. trim( $info['meta_tag_values']['article_author'] ).'" />';
 		endif;
 
-		if( !empty( $info['meta_tag_values']['article_publisher'] ) ):
+		if( isset( $info['meta_tag_values']['article_publisher'] ) && !empty( $info['meta_tag_values']['article_publisher'] ) ):
 			$info['html_output'] .= PHP_EOL . '<meta property="article:publisher" content="'. trim( $info['meta_tag_values']['article_publisher'] ) .'" />';
 		endif;
 
-		$info['html_output'] .= PHP_EOL . '<meta property="article:published_time" content="'. trim( $info['meta_tag_values']['article_published_time'] ) .'" />';
-		$info['html_output'] .= PHP_EOL . '<meta property="article:modified_time" content="'. trim( $info['meta_tag_values']['article_modified_time'] ) .'" />';
-		$info['html_output'] .= PHP_EOL . '<meta property="og:updated_time" content="'. trim( $info['meta_tag_values']['og_modified_time'] ) .'" />';
-		$info['html_output'] .= PHP_EOL . '<meta property="fb:app_id" content="'. trim( $info['meta_tag_values']['fb_app_id'] ).'" />';
+		if( isset( $info['meta_tag_values']['article_published_time'] ) && !empty( $info['meta_tag_values']['article_published_time'] ) ):
+			$info['html_output'] .= PHP_EOL . '<meta property="article:published_time" content="'. trim( $info['meta_tag_values']['article_published_time'] ) .'" />';
+		endif;
+
+		if( isset( $info['meta_tag_values']['article_modified_time'] ) && !empty( $info['meta_tag_values']['article_modified_time'] ) ):
+			$info['html_output'] .= PHP_EOL . '<meta property="article:modified_time" content="'. trim( $info['meta_tag_values']['article_modified_time'] ) .'" />';
+		endif;
+
+		if( isset( $info['meta_tag_values']['og_modified_time'] ) && !empty( $info['meta_tag_values']['og_modified_time'] ) ):
+			$info['html_output'] .= PHP_EOL . '<meta property="og:updated_time" content="'. trim( $info['meta_tag_values']['og_modified_time'] ) .'" />';
+		endif;
+
+		if( isset( $info['meta_tag_values']['fb_app_id'] ) && !empty( $info['meta_tag_values']['fb_app_id'] ) ):
+			$info['html_output'] .= PHP_EOL . '<meta property="fb:app_id" content="'. trim( $info['meta_tag_values']['fb_app_id'] ).'" />';
+		endif;
+
 	endif;
 
 	return $info;
@@ -411,22 +439,35 @@ function swp_twitter_card_html($info) {
 	if( false === is_singular() ) {
 		return $info;
 	}
-	
+
 	global $swp_user_options;
 
 	if ( is_singular() && $swp_user_options['swp_twitter_card'] ) :
-		$info['html_output'] .= PHP_EOL . '<meta name="twitter:card" content="'. trim( $info['meta_tag_values']['twitter_card'] ) .'">';
-		$info['html_output'] .= PHP_EOL . '<meta name="twitter:title" content="' . trim( $info['meta_tag_values']['twitter_title'] ) . '">';
-		$info['html_output'] .= PHP_EOL . '<meta name="twitter:description" content="' . trim( $info['meta_tag_values']['twitter_description'] ) . '">';
-		if( !empty($info['meta_tag_values']['twitter_image']) ):
+
+		if( isset( $info['meta_tag_values']['twitter_card'] ) && !empty( $info['meta_tag_values']['twitter_card'] ) ) :
+			$info['html_output'] .= PHP_EOL . '<meta name="twitter:card" content="'. trim( $info['meta_tag_values']['twitter_card'] ) .'">';
+		endif;
+
+		if( isset( $info['meta_tag_values']['twitter_title'] ) && !empty( $info['meta_tag_values']['twitter_title'] ) ) :
+			$info['html_output'] .= PHP_EOL . '<meta name="twitter:title" content="' . trim( $info['meta_tag_values']['twitter_title'] ) . '">';
+		endif;
+
+		if( isset( $info['meta_tag_values']['twitter_description'] ) && !empty( $info['meta_tag_values']['twitter_description'] ) ) :
+			$info['html_output'] .= PHP_EOL . '<meta name="twitter:description" content="' . trim( $info['meta_tag_values']['twitter_description'] ) . '">';
+		endif;
+
+		if( isset( $info['meta_tag_values']['twitter_image'] ) && !empty($info['meta_tag_values']['twitter_image']) ):
 			$info['html_output'] .= PHP_EOL . '<meta name="twitter:image" content="' . trim( $info['meta_tag_values']['twitter_image'] ) . '">';
 		endif;
-		if ( !empty( $info['meta_tag_values']['twitter_site'] ) ) :
+
+		if ( isset( $info['meta_tag_values']['twitter_site'] ) && !empty( $info['meta_tag_values']['twitter_site'] ) ) :
 			$info['html_output'] .= PHP_EOL . '<meta name="twitter:site" content="' . trim( $info['meta_tag_values']['twitter_site'] ) . '">';
 		endif;
-		if ( !empty( $info['meta_tag_values']['twitter_creator'] ) ) :
+
+		if ( isset( $info['meta_tag_values']['twitter_creator'] ) && !empty( $info['meta_tag_values']['twitter_creator'] ) ) :
 			$info['html_output'] .= PHP_EOL . '<meta name="twitter:creator" content="' . trim( $info['meta_tag_values']['twitter_creator'] ) . '">';
 		endif;
+
 	endif;
 
 	return $info;

--- a/functions/update-checker/github-checker.php
+++ b/functions/update-checker/github-checker.php
@@ -1,8 +1,8 @@
 <?php
 
-if ( !class_exists('PucGitHubChecker_3_1', false) ):
+if ( !class_exists('swp_PucGitHubChecker_3_1', false) ):
 
-class PucGitHubChecker_3_1 extends PluginUpdateChecker_3_1 {
+class swp_PucGitHubChecker_3_1 extends swp_PluginUpdateChecker_3_1 {
 	/**
 	 * @var string GitHub username.
 	 */
@@ -54,10 +54,10 @@ class PucGitHubChecker_3_1 extends PluginUpdateChecker_3_1 {
 	 * Retrieve details about the latest plugin version from GitHub.
 	 *
 	 * @param array $unusedQueryArgs Unused.
-	 * @return PluginInfo_3_1
+	 * @return swp_PluginInfo_3_1
 	 */
 	public function requestInfo($unusedQueryArgs = array()) {
-		$info = new PluginInfo_3_1();
+		$info = new swp_PluginInfo_3_1();
 		$info->filename = $this->pluginFile;
 		$info->slug = $this->slug;
 
@@ -359,7 +359,7 @@ class PucGitHubChecker_3_1 extends PluginUpdateChecker_3_1 {
 	 * Copy plugin metadata from a file header to a PluginInfo object.
 	 *
 	 * @param array $fileHeader
-	 * @param PluginInfo_3_1 $pluginInfo
+	 * @param swp_PluginInfo_3_1 $pluginInfo
 	 */
 	protected function setInfoFromHeader($fileHeader, $pluginInfo) {
 		$headerToPropertyMap = array(
@@ -390,7 +390,7 @@ class PucGitHubChecker_3_1 extends PluginUpdateChecker_3_1 {
 	 * Copy plugin metadata from the remote readme.txt file.
 	 *
 	 * @param string $ref GitHub tag or branch where to look for the readme.
-	 * @param PluginInfo_3_1 $pluginInfo
+	 * @param swp_PluginInfo_3_1 $pluginInfo
 	 */
 	protected function setInfoFromRemoteReadme($ref, $pluginInfo) {
 		$readmeTxt = $this->getRemoteFile('readme.txt', $ref);

--- a/social-warfare-pro.php
+++ b/social-warfare-pro.php
@@ -67,10 +67,11 @@ function swp_mismatch_notification() {
 
 /**
  * A class for checking for plugin updates
- *
+ *THIS IS WHAT NEEDS TO BE WHITE LABELLED
+ *MAKE SURE EVERYTHING IS UPDATED TO USE THE NEW FUNCTION NAMES
  */
 require_once SWPP_PLUGIN_DIR . '/functions/update-checker/plugin-update-checker.php';
-$swpp_github_checker = PucFactory::getLatestClassVersion('PucGitHubChecker');
+$swpp_github_checker = swp_PucFactory::getLatestClassVersion('PucGitHubChecker');
 $swpp_update_checker = new $swpp_github_checker(
     'https://github.com/warfare-plugins/social-warfare-pro/',
     __FILE__,


### PR DESCRIPTION
This updates a number of classes in the checker system to use the prefix swp_

It might be possible more classes and functions can have their names updated.  Currently, plugin-update-checker.php and github-checker.php are the files with the classes that have been changed.

Records of scans for the usages of these classes is included, and should reflect where changes occurred for instances and calling of these classes.