### PR TITLE
Jetpack: remove deprecated filter

### DIFF
--- a/functions/frontend-output/header-meta-tags.php
+++ b/functions/frontend-output/header-meta-tags.php
@@ -95,7 +95,6 @@ function swp_open_graph_values($info){
 	 * Disable Jetpack's Open Graph tags
 	 *
 	 */
-	add_filter( 'jetpack_enable_opengraph', '__return_false', 99 );
 	add_filter( 'jetpack_enable_open_graph', '__return_false', 99 );
 
 	/**
@@ -383,7 +382,7 @@ function swp_twitter_card_values($info) {
 		endif;
 
 		/**
-		 * JET PACK: If ours are activated, disable theirs
+		 * Jetpack: If ours are activated, disable theirs
 		 *
 		 */
 		add_filter( 'jetpack_disable_twitter_cards', '__return_true', 99 );


### PR DESCRIPTION
This filter was removed from Jetpack 5 years ago, and replaced by another filter that you are already using:
https://github.com/Automattic/jetpack/commit/e934b5601698c44e40785e043b2ace0675f34321

I think it is safe to remove that old filter now, and thus avoid displaying deprecation notices on sites with WP Debug active.