### PR TITLE
Fix - Undefined index: shortUrl #832

### DIFF
--- a/lib/url-management/SWP_Pro_Rebrandly.php
+++ b/lib/url-management/SWP_Pro_Rebrandly.php
@@ -90,6 +90,11 @@ class SWP_Pro_Rebrandly extends SWP_Link_Shortener {
 
 		// Process the response.
 		$response = json_decode($result, true);
+		// Check for shortUrl before adding prefix.
+		// Undefined index: shortUrl #832
+		if ( ! isset( $response['shortUrl'] ) ) {
+			return $url;
+		}
 		$response['shortUrl'] = $this->add_prefix( $response['shortUrl'] );
 
 		if( isset( $response['shortUrl'] ) ) {


### PR DESCRIPTION
Check for shortUrl to exists from the response before adding the prefix and testing if shortUrl exists.
Once you do add_prefix  the isset check after that will always be true.