### PR TITLE
Replaced 'require_once' with 'require' to prevent conflicts with the Elementor plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .remote-sync.json
 .gitignore 
+/.vscode

--- a/lib/meta-box/inc/fields/file-upload.php
+++ b/lib/meta-box/inc/fields/file-upload.php
@@ -44,11 +44,14 @@ class SWPMB_File_Upload_Field extends SWPMB_Media_Field {
 		return $field;
 	}
 
-	/**
-	 * Template for media item.
+    /**
+	 * Template for media item.      
+	 *
+	 * @since  4.4.1  | 21 AUG 2023 | Replaced 'require_once' with 'require' to prevent conflicts with the Elementor plugin.
+	 *
 	 */
 	public static function print_templates() {
 		parent::print_templates();
-		require_once SWPMB_INC_DIR . 'templates/upload.php';
+		require SWPMB_INC_DIR . 'templates/upload.php';
 	}
 }

--- a/lib/meta-box/inc/fields/image-advanced.php
+++ b/lib/meta-box/inc/fields/image-advanced.php
@@ -85,11 +85,14 @@ class SWPMB_Image_Advanced_Field extends SWPMB_Media_Field {
 		return SWPMB_Image_Field::format_single_value( $field, $value, $args, $post_id );
 	}
 
-	/**
-	 * Template for media item.
+    /**
+	 * Template for media item.      
+	 *
+	 * @since  4.4.1  | 21 AUG 2023 | Replaced 'require_once' with 'require' to prevent conflicts with the Elementor plugin.
+	 *
 	 */
 	public static function print_templates() {
 		parent::print_templates();
-		require_once SWPMB_INC_DIR . 'templates/image-advanced.php';
+		require SWPMB_INC_DIR . 'templates/image-advanced.php';
 	}
 }

--- a/lib/meta-box/inc/fields/media.php
+++ b/lib/meta-box/inc/fields/media.php
@@ -228,9 +228,12 @@ class SWPMB_Media_Field extends SWPMB_File_Field {
 	}
 
 	/**
-	 * Template for media item.
+	 * Template for media item.      
+	 *
+	 * @since  4.4.1  | 21 AUG 2023 | Replaced 'require_once' with 'require' to prevent conflicts with the Elementor plugin.
+	 *
 	 */
 	public static function print_templates() {
-		require_once SWPMB_INC_DIR . 'templates/media.php';
+		require SWPMB_INC_DIR . 'templates/media.php';
 	}
 }

--- a/lib/meta-box/inc/fields/video.php
+++ b/lib/meta-box/inc/fields/video.php
@@ -139,10 +139,13 @@ class SWPMB_Video_Field extends SWPMB_Media_Field {
 	}
 
 	/**
-	 * Template for media item.
+	 * Template for media item.      
+	 *
+	 * @since  4.4.1  | 21 AUG 2023 | Replaced 'require_once' with 'require' to prevent conflicts with the Elementor plugin.
+	 *
 	 */
 	public static function print_templates() {
 		parent::print_templates();
-		require_once SWPMB_INC_DIR . 'templates/video.php';
+		require SWPMB_INC_DIR . 'templates/video.php';
 	}
 }


### PR DESCRIPTION
Fixed this issue: https://github.com/warfare-plugins/social-warfare/issues/872

Replaced 'require_once' with 'require' to prevent conflicts with the Elementor plugin.